### PR TITLE
Improvements to the Maven setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>add-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -121,24 +121,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.0.0</version>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>gh-pages</directory>
-							<includes>
-								<include>**/*</include>
-							</includes>
-							<excludes>
-								<exclude>**/.git/</exclude>
-							</excludes>
-							<followSymlinks>false</followSymlinks>
-						</fileset>
-					</filesets>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.meertens.mtas</groupId>
 	<artifactId>mtas</artifactId>
-	<version>7.0.1</version>
+	<version>7.0.1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<licenses>
 		<license>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
 							<javadocFriendlyComments>true</javadocFriendlyComments>
 							<packageName>mtas.parser.function</packageName>
 							<sourceDirectory>${project.basedir}/src/mtas/parser/function/</sourceDirectory>
-							<outputDirectory>${project.basedir}/generated-sources/javacc</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -152,19 +152,19 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>cobertura</goal>
-            </goals>
-            <configuration>
-              <formats>
-                <format>xml</format>
-              </formats>
-            </configuration>
-          </execution>
-        </executions>
+				<executions>
+						<execution>
+								<phase>package</phase>
+								<goals>
+										<goal>cobertura</goal>
+								</goals>
+								<configuration>
+										<formats>
+												<format>xml</format>
+										</formats>
+								</configuration>
+						</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,10 +133,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.6</version>
-				<configuration>
-					<siteDirectory>${project.basedir}/src/site/</siteDirectory>
-					<outputDirectory>${project.basedir}/gh-pages/</outputDirectory>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,16 +151,19 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
-				<configuration>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>clean</goal>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>cobertura</goal>
+            </goals>
+            <configuration>
+              <formats>
+                <format>xml</format>
+              </formats>
+            </configuration>
+          </execution>
+        </executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,64 +149,37 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<executions>
-						<execution>
-								<phase>package</phase>
-								<goals>
-										<goal>cobertura</goal>
-								</goals>
-								<configuration>
-										<formats>
-												<format>xml</format>
-										</formats>
-								</configuration>
-						</execution>
-				</executions>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<executions>
+							<execution>
+									<id>default-prepare-agent</id>
+									<goals>
+											<goal>prepare-agent</goal>
+									</goals>
+									<configuration>
+											<propertyName>jacoco.argLine</propertyName>
+									</configuration>
+							</execution>
+							<execution>
+									<id>default-report</id>
+									<phase>prepare-package</phase>
+									<goals>
+											<goal>report</goal>
+									</goals>
+							</execution>
+							<execution>
+									<id>default-check</id>
+									<goals>
+											<goal>check</goal>
+									</goals>
+									<configuration>
+											<rules />
+									</configuration>
+							</execution>
+					</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.9</version>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-report</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-check</id>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<rules><!-- implementation is needed only for Maven 2 -->
-								<rule implementation="org.jacoco.maven.RuleConfiguration">
-									<element>BUNDLE</element>
-									<limits><!-- implementation is needed only for Maven 2 -->
-										<limit implementation="org.jacoco.report.check.Limit">
-											<counter>COMPLEXITY</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.60</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
+			</plugins>
 	</build>
 	<reporting>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.9</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pom.xml
+++ b/pom.xml
@@ -149,37 +149,37 @@
 				</configuration>
 			</plugin>
 			<plugin>
-					<groupId>org.jacoco</groupId>
-					<artifactId>jacoco-maven-plugin</artifactId>
-					<executions>
-							<execution>
-									<id>default-prepare-agent</id>
-									<goals>
-											<goal>prepare-agent</goal>
-									</goals>
-									<configuration>
-											<propertyName>jacoco.argLine</propertyName>
-									</configuration>
-							</execution>
-							<execution>
-									<id>default-report</id>
-									<phase>prepare-package</phase>
-									<goals>
-											<goal>report</goal>
-									</goals>
-							</execution>
-							<execution>
-									<id>default-check</id>
-									<goals>
-											<goal>check</goal>
-									</goals>
-									<configuration>
-											<rules />
-									</configuration>
-							</execution>
-					</executions>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+						<execution>
+								<id>default-prepare-agent</id>
+								<goals>
+										<goal>prepare-agent</goal>
+								</goals>
+								<configuration>
+										<propertyName>jacoco.argLine</propertyName>
+								</configuration>
+						</execution>
+						<execution>
+								<id>default-report</id>
+								<phase>prepare-package</phase>
+								<goals>
+										<goal>report</goal>
+								</goals>
+						</execution>
+						<execution>
+								<id>default-check</id>
+								<goals>
+										<goal>check</goal>
+								</goals>
+								<configuration>
+										<rules />
+								</configuration>
+						</execution>
+				</executions>
 			</plugin>
-			</plugins>
+		</plugins>
 	</build>
 	<reporting>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 						</goals>
 						<configuration>
 							<sources>
-								<source>${project.basedir}/generated-sources/</source>
+								<source>${project.basedir}/target/generated-sources/javacc</source>
 								<source>${project.basedir}/resources/</source>
 							</sources>
 						</configuration>
@@ -102,7 +102,6 @@
 							<javadocFriendlyComments>true</javadocFriendlyComments>
 							<packageName>mtas.parser.cql</packageName>
 							<sourceDirectory>${project.basedir}/src/mtas/parser/cql</sourceDirectory>
-							<outputDirectory>${project.basedir}/generated-sources</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -116,7 +115,7 @@
 							<javadocFriendlyComments>true</javadocFriendlyComments>
 							<packageName>mtas.parser.function</packageName>
 							<sourceDirectory>${project.basedir}/src/mtas/parser/function/</sourceDirectory>
-							<outputDirectory>${project.basedir}/generated-sources</outputDirectory>
+							<outputDirectory>${project.basedir}/generated-sources/javacc</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -128,16 +127,6 @@
 					<filesets>
 						<fileset>
 							<directory>gh-pages</directory>
-							<includes>
-								<include>**/*</include>
-							</includes>
-							<excludes>
-								<exclude>**/.git/</exclude>
-							</excludes>
-							<followSymlinks>false</followSymlinks>
-						</fileset>
-						<fileset>
-							<directory>generated-sources</directory>
 							<includes>
 								<include>**/*</include>
 							</includes>


### PR DESCRIPTION
I am trying to improve the Maven build of MTAS and to clean up the POM. This PR includes a number of small changes:

* keep only one test coverage plugin (jacoco) and drop the other (cobertura; which doesn't work well with Java 8)
* Maintain generated javacc sources in their default location under target
* Remove unnecessary configurations to the Maven Clean plugin

If acceptable, I'd also offer converting the project to the default Maven directory layout where production sources/resources are under `src/main` and test sources/resources are under `src/test` which would further reduce the need for explicit configurations in the POM and prefer convention over configuration.

@betoboullosa @matthijsbrouwer 