### PR TITLE
Command line build complains about missing jacoco version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.7.9</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>


### PR DESCRIPTION
Set jacoco plugin version to avoid Maven complaining about a missingversion during command-line builds.